### PR TITLE
Disabling Xero option from menu

### DIFF
--- a/window/window_maker.py
+++ b/window/window_maker.py
@@ -103,7 +103,7 @@ class Window(object):
         build_statement_btn = tk.Button(options_frame, text="Make Statement", command=self.build_single_statement)
         build_statement_btn.pack(padx=25, pady=20, side="left")
 
-        xero_btn = tk.Button(options_frame, text="Xero", command=self.start_xero_process)
+        xero_btn = tk.Button(options_frame, text="Xero")
         xero_btn.pack(padx=25, pady=20, side="left")
 
         self.basic_btn_frame(main_frame)


### PR DESCRIPTION
Removing Xero api calls from main menu due to deprecations.